### PR TITLE
Use compile_env instead of get_env to suppress the only warning in code.

### DIFF
--- a/lib/recase/cases/generic.ex
+++ b/lib/recase/cases/generic.ex
@@ -4,8 +4,7 @@ defmodule Recase.Generic do
   This module should not be used directly.
   """
 
-  # credo:disable-for-next-line /\.ApplicationConfigInModuleAttribute/
-  @splitters Application.get_env(:recase, :delimiters, [
+  @splitters Application.compile_env(:recase, :delimiters, [
                ?\s,
                ?\n,
                ?\t,


### PR DESCRIPTION
Very simple commit to suppress an incessant warning in my pipeline :-) Pet your peeves!